### PR TITLE
Implement site:<domain> filter, add indexing of outgoing links

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -69,7 +69,7 @@ func createTables(db *sql.DB) {
         url TEXT NOT NULL,
         FOREIGN KEY(url) REFERENCES pages(url)
     )`,
-    `CREATE VIRTUAL TABLE IF NOT EXISTS external_links USING fts5 (url, tokenize="trigram")`,
+		`CREATE VIRTUAL TABLE IF NOT EXISTS external_links USING fts5 (url, tokenize="trigram")`,
 	}
 
 	for _, query := range queries {
@@ -110,16 +110,16 @@ func FulltextSearchWords(db *sql.DB, phrase string) []types.PageData {
 	util.Check(err)
 	defer rows.Close()
 
-  var pageData types.PageData
-  var pages []types.PageData
-  for rows.Next() {
-    if err := rows.Scan(&pageData.URL); err != nil {
-      log.Fatalln(err)
-    }
-    pageData.Title = pageData.URL
-    pages = append(pages, pageData)
-  }
-  return pages
+	var pageData types.PageData
+	var pages []types.PageData
+	for rows.Next() {
+		if err := rows.Scan(&pageData.URL); err != nil {
+			log.Fatalln(err)
+		}
+		pageData.Title = pageData.URL
+		pages = append(pages, pageData)
+	}
+	return pages
 }
 
 func GetDomainCount(db *sql.DB) int {

--- a/html/assets/style.css
+++ b/html/assets/style.css
@@ -142,6 +142,20 @@ nav li {
     height: auto;
 }
 
+/* Search Results */
+.result-nav-list {
+    display: grid;
+    grid-auto-flow: column;
+    justify-content: start;
+    grid-column-gap: 0.75rem;
+    padding-bottom: 0;
+    font-size: 1.8rem;
+}
+
+.result__current {
+    /* font-weight: bold; */
+    text-decoration-line: underline;
+}
 
 /* Entries */
 

--- a/html/search.html
+++ b/html/search.html
@@ -2,6 +2,7 @@
 {{ template "nav" . }}
 <main id="results" class="flow2">
     <h1>{{ .Data.Title }} {{ if ne .Data.Site "" }} for {{ .Data.Site }} {{ end }}</h1>
+
     <form method="GET" class="search">
         <label for="search">Search {{ .SiteName }} </label>
         <span class="search__input">
@@ -14,18 +15,29 @@
             </button>
         </span>
     </form>
-    <nav>
-        <ul class="result-nav-list">
-            <li title="content from webring sites only"
-                class="{{ if .Data.IsInternal }} result__current {{ end }}">
-                <a href="/?q={{ .Data.Query }}">Webring</a>
-            </li>
-            <li title="content linked from webring sites, but which reside outside it"
-                class="{{ if .Data.IsInternal | not }} result__current {{ end }}">
-                <a href="/outgoing?q={{ .Data.Query }}">Outgoing</a>
-            </li>
-        </ul>
-    </nav>
+    {{ if ne .Data.Site "" }} 
+     <!-- add a button to clear the search results if a site:<domain> param has been used -->
+        <form method="GET" class="search">
+            <span class="search__input">
+                <input type="hidden" minlength="1" required name="q" placeholder="Search" value="{{ .Data.Query }}" class="search-box" id="search">
+                <button type="submit" value="clear" name="clear">Clear</button>
+                </button>
+            </span>
+        </form>
+    {{ else }}
+        <nav>
+            <ul class="result-nav-list">
+                <li title="content from webring sites only"
+                    class="{{ if .Data.IsInternal }} result__current {{ end }}">
+                    <a href="/?q={{ .Data.Query }}">Webring</a>
+                </li>
+                <li title="content linked from webring sites, but which reside outside it"
+                    class="{{ if .Data.IsInternal | not }} result__current {{ end }}">
+                    <a href="/outgoing?q={{ .Data.Query }}">Outgoing</a>
+                </li>
+            </ul>
+        </nav>
+    {{ end }}
     <article>
         <ul role="list" class="flow2 two-columns width-126ch">
         {{ range $index, $a := .Data.Pages }}

--- a/html/search.html
+++ b/html/search.html
@@ -1,7 +1,7 @@
 {{ template "head" . }}
 {{ template "nav" . }}
 <main id="results" class="flow2">
-    <h1>Results</h1>
+    <h1>{{ .Data.Title }}</h1>
     <form method="GET" class="search">
         <label for="search">Search {{ .SiteName }}</label>
         <span class="search__input">
@@ -11,6 +11,18 @@
             </button>
         </span>
     </form>
+    <nav>
+        <ul class="result-nav-list">
+            <li title="content from webring sites only"
+                class="{{ if .Data.IsInternal }} result__current {{ end }}">
+                <a href="/?q={{ .Data.Query }}">Webring</a>
+            </li>
+            <li title="content linked from webring sites, but which reside outside it"
+                class="{{ if .Data.IsInternal | not }} result__current {{ end }}">
+                <a href="/outgoing?q={{ .Data.Query }}">Outgoing</a>
+            </li>
+        </ul>
+    </nav>
     <article>
         <ul role="list" class="flow2 two-columns width-126ch">
         {{ range $index, $a := .Data.Pages }}

--- a/html/search.html
+++ b/html/search.html
@@ -1,11 +1,14 @@
 {{ template "head" . }}
 {{ template "nav" . }}
 <main id="results" class="flow2">
-    <h1>{{ .Data.Title }}</h1>
+    <h1>{{ .Data.Title }} {{ if ne .Data.Site "" }} for {{ .Data.Site }} {{ end }}</h1>
     <form method="GET" class="search">
-        <label for="search">Search {{ .SiteName }}</label>
+        <label for="search">Search {{ .SiteName }} </label>
         <span class="search__input">
             <input type="search" minlength="1" required name="q" placeholder="Search" value="{{ .Data.Query }}" class="search-box" id="search">
+            {{ if ne .Data.Site "" }} 
+                <input type="hidden" value="{{ .Data.Site }}" name="site">
+            {{ end }}
             <button type="submit" class="search__button" aria-label="Search" title="Search">
                 <svg viewBox="0 0 420 300" xmlns="http://www.w3.org/2000/svg" baseProfile="full" style="background:var(--secondary)" width="42" height="30" fill="none"><path d="M90 135q60-60 120-60 0 0 0 0 60 0 120 60m-120 60a60 60 0 01-60-60 60 60 0 0160-60 60 60 0 0160 60 60 60 0 01-60 60m45-15h0l30 30m-75-15h0v45m-45-60h0l-30 30" stroke-width="81" stroke-linecap="square" stroke-linejoin="round" stroke="var(--primary)"/></svg>
             </button>

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -80,7 +80,7 @@ func Ingest(config types.Config) {
 	var count int
 	var batchsize = 100
 	batch := make([]types.SearchFragment, 0, 0)
-  var externalLinks []string
+	var externalLinks []string
 
 	scanner := bufio.NewScanner(buf)
 	for scanner.Scan() {
@@ -142,8 +142,8 @@ func Ingest(config types.Config) {
 			page.Lang = rawdata
 		case "keywords":
 			processed = strings.Split(strings.ReplaceAll(payload, ", ", ","), ",")
-    case "non-webring-link":
-      externalLinks = append(externalLinks, payload)
+		case "non-webring-link":
+			externalLinks = append(externalLinks, payload)
 		default:
 			continue
 		}
@@ -166,7 +166,7 @@ func Ingest(config types.Config) {
 
 		if len(pages) > batchsize {
 			ingestBatch(db, batch, pages, externalLinks)
-      externalLinks = make([]string, 0, 0)
+			externalLinks = make([]string, 0, 0)
 			batch = make([]types.SearchFragment, 0, 0)
 			// TODO: make sure we don't partially insert any page data
 			pages = make(map[string]types.PageData)
@@ -189,7 +189,7 @@ func ingestBatch(db *sql.DB, batch []types.SearchFragment, pageMap map[string]ty
 	database.InsertManyDomains(db, pages)
 	database.InsertManyPages(db, pages)
 	database.InsertManyWords(db, batch)
-  database.InsertManyExternalLinks(db, links)
+	database.InsertManyExternalLinks(db, links)
 	log.Println("finished ingesting batch")
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -68,6 +68,7 @@ func (h RequestHandler) searchRoute(res http.ResponseWriter, req *http.Request) 
 			query = words[0]
 		}
 
+		// how to use: https://gist.github.com/cblgh/29991ba0a9e65cccbe14f4afd7c975f1
 		if parts, exists := params["site"]; exists && parts[0] != "" {
 			// make sure we only have the domain, and no protocol prefix
 			domain = strings.TrimPrefix(parts[0], "https://")

--- a/server/server.go
+++ b/server/server.go
@@ -25,8 +25,10 @@ type TemplateView struct {
 }
 
 type SearchData struct {
-	Query string
-	Pages []types.PageData
+	Query      string
+	Title      string
+	Pages      []types.PageData
+	IsInternal bool
 }
 
 type IndexData struct {
@@ -83,8 +85,10 @@ func (h RequestHandler) searchRoute(res http.ResponseWriter, req *http.Request) 
 	}
 
 	view.Data = SearchData{
-		Query: query,
-		Pages: pages,
+		Title:      "Results",
+		Query:      query,
+		Pages:      pages,
+		IsInternal: true,
 	}
 	h.renderView(res, "search", view)
 }
@@ -112,8 +116,10 @@ func (h RequestHandler) externalSearchRoute(res http.ResponseWriter, req *http.R
 	}
 
 	view.Data = SearchData{
-		Query: query,
-		Pages: pages,
+		Title:      "External Results",
+		Query:      query,
+		Pages:      pages,
+		IsInternal: false,
 	}
 	h.renderView(res, "search", view)
 }
@@ -191,8 +197,8 @@ func Serve(config types.Config) {
 
 	http.HandleFunc("/about", handler.aboutRoute)
 	http.HandleFunc("/", handler.searchRoute)
-	http.HandleFunc("/external", handler.externalSearchRoute)
-	http.HandleFunc("/random/external", handler.randomExternalRoute)
+	http.HandleFunc("/outgoing", handler.externalSearchRoute)
+	http.HandleFunc("/random/outgoing", handler.randomExternalRoute)
 	http.HandleFunc("/random", handler.randomRoute)
 	http.HandleFunc("/webring", handler.webringRoute)
 	http.HandleFunc("/filtered", handler.filteredRoute)


### PR DESCRIPTION
* Implemented a search function allowing visitors to search the wider web from
  the perspective of webring denizens, by way of indexing and making searchable
  the webring's outgoing links
* Implemented the `site:<domain>` filter to allow searching the webring for results from a single site
* Made it possible for static sites to implement search for their sites using Lieu, [example code](https://gist.github.com/cblgh/29991ba0a9e65cccbe14f4afd7c975f1)
