### PR TITLE
Add opensearch metadata for browser integration

### DIFF
--- a/html/assets/opensearch.xml
+++ b/html/assets/opensearch.xml
@@ -1,0 +1,7 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+    <ShortName>Lieu</ShortName>
+    <Description>Lieu - the search for the new—endless</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Image width="16" height="16" type="image/x-icon">https://lieu.cblgh.org/assets/favicon.ico</Image>
+    <Url type="text/html" method="get" template="https://lieu.cblgh.org/?q={searchTerms}"/>
+</OpenSearchDescription>

--- a/html/head.html
+++ b/html/head.html
@@ -32,6 +32,8 @@
 
         <link rel="canonical" href="https://lieu.cblgh.org/">
 
+        <link rel="search" type="application/opensearchdescription+xml" title="Lieu" href="/assets/opensearch.xml">
+
     </head>
     <body>
 {{ end }}


### PR DESCRIPTION
This allows Lieu to be discovered as a search engine by browsers, which then can be set as the default search engine for example.

Looks like this in Firefox: 
![leu](https://user-images.githubusercontent.com/882186/139724891-9b647354-dca0-4b12-8c0b-bf105247bdc7.png)
