### PR TITLE
Path-enhanced crawling

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -6,7 +6,7 @@ do
     if [ $os = "windows" ]; then
         executable="lieu.exe"
     fi
-    env GOOS="$os" go build -ldflags "-s -w"
+    env GOOS="$os" go build -tags fts5 -ldflags "-s -w"
     tar czf "lieu-$os.tar.gz" README.md html/ data/ lieu.toml "$executable"
     echo "lieu-$os.tar.gz"
     rm -f "$executable"

--- a/server/server.go
+++ b/server/server.go
@@ -229,10 +229,10 @@ func (h RequestHandler) renderView(res http.ResponseWriter, tmpl string, view *T
 
 func WriteTheme(config types.Config) {
 	theme := config.Theme
-  // no theme is set, use the default
-  if theme.Foreground == "" {
-    return
-  }
+	// no theme is set, use the default
+	if theme.Foreground == "" {
+		return
+	}
 	colors := fmt.Sprintf(`:root {
   --primary: %s;
   --secondary: %s;


### PR DESCRIPTION
Webring sites passed to Lieu which end with a path, e.g. `https://example.com/site/lupin` will now only have their children pages crawled (as opposed to allowing all pages of `example.com` being crawled). 

This falls more in line with expectations for webring sites which might exist on shared hosting, or just sites which have separate areas that should not be crawled.

Thanks @amolith for the issue!