### PR TITLE
Feature: advanced search

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ engine, a way for personal webrings to increase serendipitous connexions.
 
 ## Usage
 
+### How to search
+
+[Search query syntax and the search API are documented in their own file](docs/querying.md)
+
+### Getting Lieu running
+
 ```
 $ lieu help
 Lieu: neighbourhood search engine

--- a/database/database.go
+++ b/database/database.go
@@ -289,9 +289,6 @@ func SearchWords(db *sql.DB, words []string, searchByScore bool, domain []string
     LIMIT 15
     `, strings.Join(wordlist, " OR "), strings.Join(domains, " OR "), strings.Join(nodomains, " AND "), strings.Join(languages, " OR "), orderType)
 
-	fmt.Println(words)
-	fmt.Println(query)
-
 	stmt, err := db.Prepare(query)
 	util.Check(err)
 	defer stmt.Close()

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -1,0 +1,32 @@
+# Querying Lieu
+
+## Search Syntax
+
+* `cat dog` - search for pages about cats or dogs, most probably both
+* `fox site:example.org` - search example.org (if indexed) for the therm "fox"
+* `fox -site:example.org` - search the entire index except `example.org` for the term "fox"
+* `emoji lang:de` - search pages that claim to mainly contain German content for the term "emoji"
+
+Things that don't matter are capitalisation and inflection.
+* All words in the query are converted to lowercase using the go standard library
+* All words are passed through [jinzhu's inflection library](https://github.com/jinzhu/inflection) for converting them to a possible singular form (note that this is intended to work with English nouns)
+
+## Search API
+
+Lieu currently only renders its results to HTML. A query can be passed to the `/` endpoint using a `GET` request.
+
+It supports two URL parameters:
+* `q` - Used for the search query
+* `site` - accepts one domain name and will have the same effect as the `site:<domain>` syntax. You can use this to make your webrings search engine double as a searchbox on your website.
+
+An example query to search `example.org` for the term "ssh" using `search.webring.example` should look like this: `https://search.webring.example/?q=ssh&site=example.org`
+
+A search-form on example.org could look a bit like this:
+```
+<form method="GET" action="https://search.webring.example">
+	<label for="search">Search example.org</label>
+	<input type="search" minlength="1" required="" name="q" placeholder="Your search query here" id="search">
+	<input type="hidden" name="site" value="example.org"> <!-- This hidden field tells lieu to only search example.org -->
+	<button type="submit">Let's go!</button>
+</form>
+```

--- a/html/index.html
+++ b/html/index.html
@@ -20,7 +20,7 @@
             <form class="search">
                 <label class="visually-hidden" for="search">Search {{ .SiteName }}</label>
                 <span class="search__input">
-                    <input type="search" required minlength="1" name="q" placeholder="{{ .Data.Placeholder }}" class="flex-grow" id="search">
+                    <input type="search" required minlength="1" name="q" placeholder="{{ .Data.Placeholder }}" class="flex-grow" id="search" maxlength="6000" >
                     <button type="submit" class="search__button" aria-label="Search" title="Search">
                         <svg viewBox="0 0 420 300" xmlns="http://www.w3.org/2000/svg" baseProfile="full" style="background:var(--secondary)" width="42" height="30" fill="none"><path d="M90 135q60-60 120-60 0 0 0 0 60 0 120 60m-120 60a60 60 0 01-60-60 60 60 0 0160-60 60 60 0 0160 60 60 60 0 01-60 60m45-15h0l30 30m-75-15h0v45m-45-60h0l-30 30" stroke-width="81" stroke-linecap="square" stroke-linejoin="round" stroke="var(--primary)"/></svg>
                     </button>

--- a/html/search.html
+++ b/html/search.html
@@ -6,7 +6,7 @@
     <form method="GET" class="search">
         <label for="search">Search {{ .SiteName }} </label>
         <span class="search__input">
-            <input type="search" minlength="1" required name="q" placeholder="Search" value="{{ .Data.Query }}" class="search-box" id="search">
+            <input type="search" minlength="1" required name="q" placeholder="Search" value="{{ .Data.Query }}" class="search-box" id="search" maxlength="6000">
             {{ if ne .Data.Site "" }} 
                 <input type="hidden" value="{{ .Data.Site }}" name="site">
             {{ end }}

--- a/server/server.go
+++ b/server/server.go
@@ -70,7 +70,7 @@ func (h RequestHandler) searchRoute(res http.ResponseWriter, req *http.Request) 
 	var langs = []string{}
 	var queryFields = []string{}
 		
-	if req.Method == http.MethodGet {
+	if req.Method == http.MethodGet{
 		params := req.URL.Query()
 		if words, exists := params["q"]; exists && words[0] != "" {
 			query = words[0]
@@ -86,24 +86,27 @@ func (h RequestHandler) searchRoute(res http.ResponseWriter, req *http.Request) 
 			domains = append(domains, domain)
 		}
 
-		var newQueryFields []string;
-		for _, word := range queryFields {
-			// This could be more efficient by splitting arrays, but I'm going with the more readable version for now
-			if strings.HasPrefix(word, "site:") {
-				domains = append(domains, strings.TrimPrefix(word, "site:"))
-			} else if strings.HasPrefix(word, "-site:") {
-				nodomains = append(nodomains, strings.TrimPrefix(word, "-site:"))
-			} else if strings.HasPrefix(word, "lang:") {
-				langs = append(langs, strings.TrimPrefix(word, "lang:"))
-			} else {
-				newQueryFields = append(newQueryFields, word)
+		// don't process if there are too many fields
+		if len(queryFields) <= 100 {
+			var newQueryFields []string;
+			for _, word := range queryFields {
+				// This could be more efficient by splitting arrays, but I'm going with the more readable version for now
+				if strings.HasPrefix(word, "site:") {
+					domains = append(domains, strings.TrimPrefix(word, "site:"))
+				} else if strings.HasPrefix(word, "-site:") {
+					nodomains = append(nodomains, strings.TrimPrefix(word, "-site:"))
+				} else if strings.HasPrefix(word, "lang:") {
+					langs = append(langs, strings.TrimPrefix(word, "lang:"))
+				} else {
+					newQueryFields = append(newQueryFields, word)
+				}
 			}
+			queryFields = newQueryFields;
 		}
-		queryFields = newQueryFields;
 		
 	}
 
-	if len(queryFields) == 0 {
+	if len(queryFields) == 0 || len(queryFields) > 100 || len(query) >= 8192 {
 		view.Data = IndexData{Tagline: h.config.General.Tagline, Placeholder: h.config.General.Placeholder}
 		h.renderView(res, "index", view)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -87,7 +87,6 @@ func (h RequestHandler) searchRoute(res http.ResponseWriter, req *http.Request) 
 		}
 
 		var newQueryFields []string;
-		fmt.Println("Query Fields:", queryFields)
 		for _, word := range queryFields {
 			// This could be more efficient by splitting arrays, but I'm going with the more readable version for now
 			if strings.HasPrefix(word, "site:") {


### PR DESCRIPTION
Adds support some selectors needed for more advanced searches like

* `-site:` to exclude sites
*  `lang:` to only search for pages that have a given language tag prefix

Note:  #14 is a version of this PR that includes a `rank:` tag that allows one to choose the ranking algorithm