### PR TITLE
Respect robots.txt

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -283,6 +283,7 @@ func Crawl(config types.Config) {
 	c.AllowedDomains = domains
 	c.AllowURLRevisit = false
 	c.DisallowedDomains = getBannedDomains(config.Crawler.BannedDomains)
+	c.IgnoreRobotsTxt = false
 
 	delay, _ := time.ParseDuration("200ms")
 	c.Limit(&colly.LimitRule{DomainGlob: "*", Delay: delay, Parallelism: 3})


### PR DESCRIPTION
Colly deceptively does not respect robots.txt by default, see https://github.com/gocolly/colly/issues/614. This PR fixes that, which makes Lieu a more polite Internet citizen.